### PR TITLE
Add prop fade helpers and PopochiuHelper autoload

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -64,6 +64,7 @@ In Godot open `Project → Project Settings → Plugins` and enable **Popochiu A
 When enabled, the plugin registers these autoloads:
 - `PFX="*res://addons/popochiu-addons/pfx/pfx.gd"`
 - `G="*res://addons/popochiu-addons/wrappers/g_autoload.gd"`
+- `PopochiuHelper="*res://addons/popochiu-addons/wrappers/popochiu_helper.gd"`
 
 Previous autoload configurations are stored in `ProjectSettings["addons/popochiu-addons/autoload_backups"]` in case you need to revert.
 
@@ -71,6 +72,7 @@ Previous autoload configurations are stored in `ProjectSettings["addons/popochiu
 Update your project-level scripts so they extend the plugin utilities:
 - GUI script: `extends "res://addons/popochiu-addons/gui/letterbox_gui.gd"`
 - Autoload override (if you manage `G` manually): `extends "res://addons/popochiu-addons/api/g.gd"`
+- Helper override (if you ship a custom one): `extends "res://addons/popochiu-addons/api/popochiu_helper.gd"`
 - Command script (optional): `extends "res://addons/popochiu-addons/wrappers/gui_commands_wrapper.gd"`
 
 If you maintain custom scripts, copy the required helper logic (letterbox transitions, PostFX hooks) into your overrides.

--- a/POPOCHIU_ADDONS_DOCUMENTATION.md
+++ b/POPOCHIU_ADDONS_DOCUMENTATION.md
@@ -12,14 +12,14 @@ This guide is the canonical reference for the Popochiu Addons plugin. It complem
 2. [Getting Started](#2-getting-started)  
 3. [Plugin Architecture](#3-plugin-architecture)  
 4. [Core Runtime APIs](#4-core-runtime-apis)  
-5. [Module Deep Dives](#5-module-deep-dives)  
-6. [Integration Workflows](#6-integration-workflows)  
-7. [Configuration Reference](#7-configuration-reference)  
-8. [Testing & QA](#8-testing--qa)  
-9. [Debugging & Troubleshooting](#9-debugging--troubleshooting)  
-10. [Performance Notes](#10-performance-notes)  
-11. [Extensibility & Roadmap](#11-extensibility--roadmap)  
-12. [File Index](#12-file-index)  
+5. [Module Deep Dives](#5-module-deep-dives)
+6. [Integration Workflows](#6-integration-workflows)
+7. [Configuration Reference](#7-configuration-reference)
+8. [Testing & QA](#8-testing--qa)
+9. [Debugging & Troubleshooting](#9-debugging--troubleshooting)
+10. [Performance Notes](#10-performance-notes)
+11. [Extensibility & Roadmap](#11-extensibility--roadmap)
+12. [File Index](#12-file-index)
 13. [Appendix: Signals & Callbacks](#13-appendix-signals--callbacks)
 
 ---
@@ -29,6 +29,7 @@ This guide is the canonical reference for the Popochiu Addons plugin. It complem
 Popochiu Addons packages cinematic and presentation-focused systems that overlie Popochiu without touching its core scripts. It currently includes:
 - **Letterbox Overlay** – Runtime letterbox/pillarbox controller, preset catalogue, Popochiu queue helpers.
 - **PostFX Pipeline (CRT)** – Configurable post-processing layer with per-room contexts and Popochiu command hooks.
+- **Prop Fade Helpers** – Tween-based alpha fades for Popochiu props with queue-ready callables and optional blocking semantics.
 
 The plugin stays additive—wrappers expose optional helpers so project overrides remain thin. Every module is shippable on its own, but the combined stack unlocks modern audiovisual flourishes for Popochiu adventures.
 
@@ -70,6 +71,8 @@ Popochiu Project
 │    └─ Extends addons/popochiu-addons/api/g.gd
 │        ├─ Delegates Letterbox calls to gui/letterbox_gui.gd + letterbox_api.gd
 │        └─ Bridges PostFX helpers to autoload `PFX`
+├─ Autoload `PopochiuHelper` -> addons/popochiu-addons/wrappers/popochiu_helper.gd
+│    └─ Extends addons/popochiu-addons/api/popochiu_helper.gd and forwards to `G`
 ├─ Autoload `PFX` -> addons/popochiu-addons/pfx/pfx.gd
 │    └─ Spawns/maintains CanvasLayer controllers per context
 ├─ GUI script -> extends addons/popochiu-addons/gui/letterbox_gui.gd
@@ -104,6 +107,10 @@ Key methods (full signatures in [Appendix](#13-appendix-signals--callbacks)):
 - `clear_pfx_config(context := "global")` / `clear_pfx_room_config(room: Node, context := "")`
 - `register_pfx_room_default(script_name: String, config := {})`
 - `get_pfx_room_default(script_name: String) -> Dictionary`
+- `fade_prop(prop, target_alpha: float, config := {})`
+- `fade_prop_in(prop, config := {})` / `fade_prop_out(prop, config := {})`
+- `queue_fade_prop(prop, target_alpha: float, config := {})`
+- `queue_fade_prop_in(prop, config := {})` / `queue_fade_prop_out(prop, config := {})`
 
 ### 4.2 `PFX` Autoload Highlights
 - Manages a cache of PostFX controllers keyed by `context` strings (`"global"`, room-specific contexts, etc.).
@@ -362,6 +369,63 @@ Popochiu.queue([
 
 ---
 
+### 5.3 Prop Fade Helpers
+
+`addons/popochiu-addons/api/g.gd` now exposes convenience tweens for fading Popochiu props (any `CanvasItem`) in and out by animating the `modulate.a` channel. The helper respects Popochiu’s queue expectations (blocking vs non-blocking) and mirrors its API on the `PopochiuHelper` autoload.
+
+**Installation & Migration**
+1. Ensure the plugin is enabled so the `PopochiuHelper` autoload points to `addons/popochiu-addons/wrappers/popochiu_helper.gd` (handled automatically in Godot → Project Settings → Plugins).
+2. Projects with custom helper overrides should extend `res://addons/popochiu-addons/api/popochiu_helper.gd` to inherit the fade helpers.
+3. No scene changes are required—helpers operate directly on existing prop instances.
+
+**Runtime API**
+```gdscript
+G.fade_prop(prop_or_name, 0.0, {"duration": 0.5})
+G.fade_prop_in(prop_or_name, {"duration": 0.75, "transition": Tween.TRANS_SINE})
+G.fade_prop_out(prop_or_name, {"hide_on_finish": true})
+await G.queue_fade_prop_in(prop_or_name, {"wait": true})()
+
+PopochiuHelper.fade_prop("Lamp", 0.2, {"delay": 0.1, "blocking": false})
+PopochiuHelper.queue_fade_prop_out("Lamp", {"wait": true, "hide_on_finish": true})
+```
+
+`prop_or_name` accepts:
+- A direct `CanvasItem` (e.g., `Sprite2D`, `Control`),
+- A Popochiu `Prop` node,
+- A prop name string/`StringName` if `G.get_prop` (or `get_prop_node`) is available.
+
+**Configuration Keys**
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `duration` | `float` | `0.4` | Seconds for the tween; `0` snaps immediately. |
+| `transition` | `Tween.TransitionType` | `Tween.TRANS_LINEAR` | Curve applied to the alpha tween. |
+| `ease` | `Tween.EaseType` | `Tween.EASE_IN_OUT` | Easing used with the transition curve. |
+| `delay` | `float` | `0.0` | Seconds to wait before the tween starts. |
+| `blocking` | `bool` | `true` | When true the helper awaits tween completion. Queue helpers force blocking semantics. |
+| `ensure_visible` | `bool` | `target_alpha > 0.0` | Forces `visible = true` before fading in. |
+| `hide_on_finish` | `bool` | `target_alpha <= 0.0` | Automatically hides the node after fading out. |
+| `from_alpha` | `float`/`null` | `null` | Optional starting alpha applied before tweening. |
+
+**Queue Integration**
+Queue helpers return callables compatible with `Popochiu.queue`:
+```gdscript
+Popochiu.queue([
+    G.queue_fade_prop_out("Spotlight", {"wait": true, "duration": 0.6}),
+    func():
+        G.show_system_text("The lamp flickers out."),
+    G.queue_fade_prop_in("Spotlight", {"wait": true, "duration": 0.4, "ensure_visible": true})
+])
+```
+
+**Debugging Tips**
+- Ensure props inherit from `CanvasItem`—3D nodes without a `modulate` property will be ignored.
+- Zero-duration fades apply instantly; combine with `hide_on_finish = true` when removing props without tweens.
+- When using prop names, confirm `G.get_prop` or `get_prop_node` returns the expected node in your Popochiu version.
+
+**Performance**: Tweens run on individual props and allocate a single `Tween` instance per call; fades are effectively free unless hundreds run simultaneously.
+
+---
+
 ---
 
 ## 6. Integration Workflows
@@ -446,6 +510,20 @@ Preset catalogue and usage examples appear in §5.1.
 
 Section 5.2 expands on each parameter family with usage tips and code examples.
 
+### 7.3 Prop Fade Keys
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `duration` | `float` | `0.4` | Seconds spent tweening to the target alpha. |
+| `transition` | `Tween.TransitionType` | `Tween.TRANS_LINEAR` | Tween curve driving the fade. |
+| `ease` | `Tween.EaseType` | `Tween.EASE_IN_OUT` | Ease applied to the transition curve. |
+| `delay` | `float` | `0.0` | Delay before the tween begins. |
+| `blocking` | `bool` | `true` | Await tween completion; queue helpers force `true`. |
+| `ensure_visible` | `bool` | `target_alpha > 0.0` | Ensures `visible = true` before fading in. |
+| `hide_on_finish` | `bool` | `target_alpha <= 0.0` | Calls `visible = false` after fading out. |
+| `from_alpha` | `float`/`null` | `null` | Optional starting alpha override. |
+
+See §5.3 for examples and queue integration patterns.
+
 ---
 
 ## 8. Testing & QA
@@ -506,6 +584,7 @@ Extension tips:
 | Path | Purpose |
 |------|---------|
 | `addons/popochiu-addons/api/g.gd` | Core autoload API consumed by wrapper `G`. |
+| `addons/popochiu-addons/api/popochiu_helper.gd` | Adds prop fade helpers mirrored by the PopochiuHelper autoload. |
 | `addons/popochiu-addons/api/gui_commands.gd` | Popochiu command helpers (forward commands to runtime). |
 | `addons/popochiu-addons/gui/letterbox_gui.gd` | GUI base script instantiating the letterbox controller. |
 | `addons/popochiu-addons/letterbox/letterbox_controller.gd` | Handles letterbox tweens, signals, and blocking state. |
@@ -515,6 +594,7 @@ Extension tips:
 | `addons/popochiu-addons/pfx/shaders/postfx_pipeline.shader.gdshader` | CRT post-processing shader. |
 | `addons/popochiu-addons/pfx/shaders/postfx_pipeline.tres` | Base material duplicated for each controller instance. |
 | `addons/popochiu-addons/wrappers/g_autoload.gd` | Drop-in autoload that extends `api/g.gd`. |
+| `addons/popochiu-addons/wrappers/popochiu_helper.gd` | Drop-in autoload that extends `api/popochiu_helper.gd`. |
 | `addons/popochiu-addons/wrappers/gui_commands_wrapper.gd` | Command wrapper extending `api/gui_commands.gd`. |
 | `INSTALLATION.md` | Root-level quick-start checklist for installing the plugin. |
 | `POPOCHIU_ADDONS_DOCUMENTATION.md` | Comprehensive technical reference for the plugin. |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Add-on systems that layer cinematic presentation tools on top of Popochiu 2.0 wi
 1. Clone or copy this repository alongside your Popochiu project.
 2. Follow `INSTALLATION.md` to copy `addons/popochiu-addons/` into your project and enable the plugin.
 3. Run `/usr/bin/godot --path . --headless --run` from your project root to confirm resources and autoloads are wired correctly.
-4. Call `G.show_letterbox_preset("cinematic_235")` or `PFX.apply_config({"crt_enabled": true})` in-game to verify both systems are active.
+4. Call `G.show_letterbox_preset("cinematic_235")`, `G.fade_prop_in("Lamp", {"duration": 0.5})`, or `PFX.apply_config({"crt_enabled": true})` in-game to verify all systems are active.
 
 ---
 
@@ -17,9 +17,13 @@ Add-on systems that layer cinematic presentation tools on top of Popochiu 2.0 wi
   *Entry point:* `addons/popochiu-addons/gui/letterbox_gui.gd` / `addons/popochiu-addons/letterbox/`.  
   *Reference:* `POPOCHIU_ADDONS_DOCUMENTATION.md` (§5.1).
 
-- **PostFX Pipeline (CRT)** – CanvasLayer-based PostFX controller with configurable scanlines, noise, curvature, chromatic aberration, and room-scoped contexts.  
-  *Entry point:* `addons/popochiu-addons/pfx/pfx.gd` / `addons/popochiu-addons/pfx/controller/`.  
+- **PostFX Pipeline (CRT)** – CanvasLayer-based PostFX controller with configurable scanlines, noise, curvature, chromatic aberration, and room-scoped contexts.
+  *Entry point:* `addons/popochiu-addons/pfx/pfx.gd` / `addons/popochiu-addons/pfx/controller/`.
   *Reference:* `POPOCHIU_ADDONS_DOCUMENTATION.md` (§5.2).
+
+- **Prop Fade Helpers** – Popochiu-safe prop tween helpers that fade any `CanvasItem` by alpha with optional queue blocking.
+  *Entry point:* `addons/popochiu-addons/api/popochiu_helper.gd` / `addons/popochiu-addons/wrappers/popochiu_helper.gd`.
+  *Reference:* `POPOCHIU_ADDONS_DOCUMENTATION.md` (§5.3).
 
 Upcoming work (tracked in `addons/popochiu-addons/doc/to-do/`) includes audio layering, lighting presets, dialogue UX upgrades, and additional cinematic helpers.
 

--- a/addons/popochiu-addons/api/g.gd
+++ b/addons/popochiu-addons/api/g.gd
@@ -3,6 +3,9 @@ extends "res://addons/popochiu/engine/interfaces/i_graphic_interface.gd"
 const LetterboxAPI := preload("res://addons/popochiu-addons/letterbox/letterbox_api.gd")
 const LETTERBOX_SCENE := preload("res://addons/popochiu-addons/letterbox/letterbox.tscn")
 const PFX_NODE_NAME := "PFX"
+const DEFAULT_PROP_FADE_DURATION := 0.4
+const DEFAULT_PROP_FADE_TRANSITION := Tween.TRANS_LINEAR
+const DEFAULT_PROP_FADE_EASE := Tween.EASE_IN_OUT
 
 func show_letterbox(config := {}):
 	if not is_instance_valid(gui):
@@ -33,24 +36,91 @@ func queue_show_letterbox(config := {}):
 		pass
 
 func queue_hide_letterbox(config := {}):
-	if not is_instance_valid(gui):
-		return func () -> void:
-			pass
-	if gui.has_method("queue_hide_letterbox"):
-		return gui.queue_hide_letterbox(config)
-	var controller := _get_letterbox_controller()
-	if controller:
-		return controller.queue_hide_letterbox(config)
-	return func () -> void:
-		pass
+        if not is_instance_valid(gui):
+                return func () -> void:
+                        pass
+        if gui.has_method("queue_hide_letterbox"):
+                return gui.queue_hide_letterbox(config)
+        var controller := _get_letterbox_controller()
+        if controller:
+                return controller.queue_hide_letterbox(config)
+        return func () -> void:
+                pass
 
 func is_letterbox_showing() -> bool:
-	if not is_instance_valid(gui):
-		return false
-	if gui.has_method("is_letterbox_showing"):
-		return gui.is_letterbox_showing()
-	var controller := _get_letterbox_controller(false)
-	return controller.is_showing() if controller else false
+        if not is_instance_valid(gui):
+                return false
+        if gui.has_method("is_letterbox_showing"):
+                return gui.is_letterbox_showing()
+        var controller := _get_letterbox_controller(false)
+        return controller.is_showing() if controller else false
+
+func fade_prop(prop: Variant, target_alpha: float, config := {}) -> Variant:
+        var canvas_item := _resolve_prop_canvas_item(prop)
+        if canvas_item == null:
+                push_warning("Popochiu Addons: Unable to fade prop; CanvasItem not found.")
+                return null
+        var fade_config := _ensure_dictionary(config)
+        var duration := float(fade_config.get("duration", DEFAULT_PROP_FADE_DURATION))
+        var transition := int(fade_config.get("transition", DEFAULT_PROP_FADE_TRANSITION))
+        var ease := int(fade_config.get("ease", DEFAULT_PROP_FADE_EASE))
+        var delay := float(fade_config.get("delay", 0.0))
+        var ensure_visible := fade_config.get("ensure_visible", target_alpha > 0.0)
+        var hide_on_finish := fade_config.get("hide_on_finish", target_alpha <= 0.0)
+        var blocking := fade_config.get("blocking", true)
+        var from_alpha = fade_config.get("from_alpha", null)
+        delay = max(delay, 0.0)
+        var clamped_target := clamp(float(target_alpha), 0.0, 1.0)
+        if ensure_visible and clamped_target > 0.0:
+                canvas_item.visible = true
+        if from_alpha != null:
+                var start_color := canvas_item.modulate
+                start_color.a = clamp(float(from_alpha), 0.0, 1.0)
+                canvas_item.modulate = start_color
+        if duration <= 0.0:
+                var end_color := canvas_item.modulate
+                end_color.a = clamped_target
+                canvas_item.modulate = end_color
+                if hide_on_finish and clamped_target <= 0.0:
+                        canvas_item.visible = false
+                return null
+        var tween := canvas_item.create_tween()
+        var property_tweener := tween.tween_property(canvas_item, "modulate:a", clamped_target, duration)
+        property_tweener.set_trans(transition)
+        property_tweener.set_ease(ease)
+        if delay > 0.0:
+                property_tweener.set_delay(delay)
+        if hide_on_finish and clamped_target <= 0.0:
+                var hide_callable := Callable(canvas_item, "set_visible").bind(false)
+                var hide_tweener := tween.tween_callback(hide_callable)
+                hide_tweener.set_delay(delay + duration)
+        if blocking:
+                await tween.finished
+        return tween
+
+func fade_prop_in(prop: Variant, config := {}) -> Variant:
+        var fade_config := _ensure_dictionary(config)
+        fade_config.erase("hide_on_finish")
+        fade_config["ensure_visible"] = fade_config.get("ensure_visible", true)
+        return fade_prop(prop, 1.0, fade_config)
+
+func fade_prop_out(prop: Variant, config := {}) -> Variant:
+        var fade_config := _ensure_dictionary(config)
+        fade_config["hide_on_finish"] = fade_config.get("hide_on_finish", true)
+        return fade_prop(prop, 0.0, fade_config)
+
+func queue_fade_prop(prop: Variant, target_alpha: float, config := {}) -> Callable:
+        var fade_config := _ensure_dictionary(config)
+        return func () -> void:
+                var queued_config := fade_config.duplicate(true)
+                queued_config["blocking"] = true
+                await fade_prop(prop, target_alpha, queued_config)
+
+func queue_fade_prop_in(prop: Variant, config := {}) -> Callable:
+        return queue_fade_prop(prop, 1.0, config)
+
+func queue_fade_prop_out(prop: Variant, config := {}) -> Callable:
+        return queue_fade_prop(prop, 0.0, config)
 
 func connect_letterbox_transition(target: Object, method: StringName, flags := 0) -> void:
 	if not is_instance_valid(gui):
@@ -157,16 +227,16 @@ func clear_pfx_room_config(room: Node, context := "") -> void:
 	_call_pfx("clear_room_config", [room, context])
 
 func register_pfx_room_default(script_name: String, config: Dictionary) -> void:
-	_call_pfx("register_room_default", [script_name, config])
+        _call_pfx("register_room_default", [script_name, config])
 
 func get_pfx_room_default(script_name: String) -> Dictionary:
-	var result = _call_pfx("get_room_default", [script_name])
-	return result if result is Dictionary else {}
+        var result = _call_pfx("get_room_default", [script_name])
+        return result if result is Dictionary else {}
 
 
 func _get_letterbox_controller(create_if_missing := true) -> LetterboxController:
-	if not is_instance_valid(gui):
-		return null
+        if not is_instance_valid(gui):
+                return null
 	var node := gui.get_node_or_null("Letterbox")
 	if node == null:
 		node = gui.get_node_or_null("PopochiuAddonsLetterbox")
@@ -188,14 +258,50 @@ func _apply_pfx_config(pfx_config, context: String) -> void:
 		push_warning("Popochiu Addons: PFX autoload not found or missing 'apply_config'. Skipping PostFX configuration.")
 
 func _call_pfx(method: StringName, args: Array = []):
-	var pfx := _get_pfx()
-	if pfx == null:
-		push_warning("Popochiu Addons: PFX autoload not found; skipping '%s' call." % method)
-		return null
-	if not pfx.has_method(method):
-		push_warning("Popochiu Addons: PFX missing method '%s'." % method)
-		return null
-	return pfx.callv(method, args)
+        var pfx := _get_pfx()
+        if pfx == null:
+                push_warning("Popochiu Addons: PFX autoload not found; skipping '%s' call." % method)
+                return null
+        if not pfx.has_method(method):
+                push_warning("Popochiu Addons: PFX missing method '%s'." % method)
+                return null
+        return pfx.callv(method, args)
+
+
+func _ensure_dictionary(value) -> Dictionary:
+        if value is Dictionary:
+                return value.duplicate(true)
+        return {}
+
+
+func _resolve_prop_canvas_item(prop: Variant) -> CanvasItem:
+        if prop is CanvasItem:
+                return prop
+        if prop is Node:
+                var node := prop as Node
+                if node is CanvasItem:
+                        return node
+        if prop is Object and prop.has_method("get_node"):
+                var prop_node = prop.get_node()
+                if prop_node is CanvasItem:
+                        return prop_node
+        if prop is String or prop is StringName:
+                var prop_name := String(prop)
+                if has_method("get_prop"):
+                        var resolved_prop = get_prop(prop_name)
+                        if resolved_prop is CanvasItem:
+                                return resolved_prop
+                        if resolved_prop is Object and resolved_prop.has_method("get_node"):
+                                var resolved_node = resolved_prop.get_node()
+                                if resolved_node is CanvasItem:
+                                        return resolved_node
+                        if resolved_prop is Node and resolved_prop is CanvasItem:
+                                return resolved_prop
+                if has_method("get_prop_node"):
+                        var prop_node = get_prop_node(prop_name)
+                        if prop_node is CanvasItem:
+                                return prop_node
+        return null
 
 
 static func _get_pfx() -> Node:

--- a/addons/popochiu-addons/api/popochiu_helper.gd
+++ b/addons/popochiu-addons/api/popochiu_helper.gd
@@ -1,0 +1,33 @@
+class_name PopochiuAddonsHelper
+extends "res://addons/popochiu/engine/helpers/popochiu_helper.gd"
+
+func fade_prop(prop: Variant, target_alpha: float, config := {}) -> Variant:
+        return G.fade_prop(prop, target_alpha, _duplicate_config(config))
+
+func fade_prop_in(prop: Variant, config := {}) -> Variant:
+        return G.fade_prop_in(prop, _duplicate_config(config))
+
+func fade_prop_out(prop: Variant, config := {}) -> Variant:
+        return G.fade_prop_out(prop, _duplicate_config(config))
+
+func queue_fade_prop(prop: Variant, target_alpha: float, config := {}) -> Callable:
+        var duplicate := _duplicate_config(config)
+        return func () -> void:
+                await G.fade_prop(prop, target_alpha, _queue_config(duplicate))
+
+func queue_fade_prop_in(prop: Variant, config := {}) -> Callable:
+        return queue_fade_prop(prop, 1.0, config)
+
+func queue_fade_prop_out(prop: Variant, config := {}) -> Callable:
+        return queue_fade_prop(prop, 0.0, config)
+
+
+func _duplicate_config(config := {}) -> Dictionary:
+        if config is Dictionary:
+                return config.duplicate(true)
+        return {}
+
+func _queue_config(config: Dictionary) -> Dictionary:
+        var duplicate := config.duplicate(true)
+        duplicate["blocking"] = true
+        return duplicate

--- a/addons/popochiu-addons/api/popochiu_helper.gd.uid
+++ b/addons/popochiu-addons/api/popochiu_helper.gd.uid
@@ -1,0 +1,1 @@
+uid://cwn9e2g61p5fx

--- a/addons/popochiu-addons/doc/popochiu-addons_features.md
+++ b/addons/popochiu-addons/doc/popochiu-addons_features.md
@@ -41,11 +41,27 @@ This document enumerates every custom system layered on top of Popochiu so the s
   3. Ensure the Popochiu `G` autoload points to the wrapper (`res://addons/popochiu-addons/wrappers/g_autoload.gd`) so the Popochiu Addons API is available alongside the letterbox helpers.
   4. Verify the plugin assets under `addons/popochiu-addons/` remain intact and Popochiu's bundled addons stay untouched.
 
-## 3. Guidelines & Tooling Updates
+## 3. Prop Fade Helpers
+- **Core Files**
+  - `addons/popochiu-addons/api/g.gd` (base autoload exposing prop fade helpers)
+  - `addons/popochiu-addons/api/popochiu_helper.gd` (PopochiuHelper extension that mirrors the API)
+  - `addons/popochiu-addons/wrappers/popochiu_helper.gd` (autoload wrapper installed by the plugin)
+- Documentation cross-link: `POPOCHIU_ADDONS_DOCUMENTATION.md` (§5.3)
+- **Key Features**
+  - Tween-based fades for any Popochiu prop (`CanvasItem`) with configurable duration, transition, easing, and delay.
+  - Optional queue callables (`queue_fade_prop*`) for Popochiu command sequencing with built-in blocking semantics.
+  - Convenience wrappers for fade-in/out plus helper autoload access so gameplay scripts can call `PopochiuHelper.fade_prop(...)`.
+- **Porting Checklist**
+  1. Enable the plugin so the `PopochiuHelper` autoload is replaced with `addons/popochiu-addons/wrappers/popochiu_helper.gd`.
+  2. Update any custom helper overrides to extend `res://addons/popochiu-addons/api/popochiu_helper.gd`.
+  3. Confirm props you plan to fade inherit from `CanvasItem` (Sprites, Controls, etc.).
+  4. Exercise both blocking (`await G.fade_prop(...)`) and non-blocking fades plus queue callables after integration.
+
+## 4. Guidelines & Tooling Updates
 - `AGENTS.md` now reminds contributors to keep Popochiu modifications outside `addons/`.
 - `doc/letterbox_todo.md` keeps QA tasks visible.
 
-## 4. Migration Strategy for New Projects
+## 5. Migration Strategy for New Projects
 1. **Prepare Autoloads**: Copy `addons/popochiu-addons/wrappers/` (autoload + command wrappers), `addons/popochiu-addons/api/`, `addons/popochiu-addons/letterbox`, `addons/popochiu-addons/gui`, and `addons/popochiu-addons/pfx`, then register `G`/`PFX` in the target project.
 2. **GUI Integration**: Point the project GUI script to extend `res://addons/popochiu-addons/gui/letterbox_gui.gd` (or merge those helpers into an existing script).
 3. **Assets**: Move `addons/popochiu-addons/pfx/` directory (contains controller/shaders) and any additional textures referenced by presets.
@@ -53,12 +69,12 @@ This document enumerates every custom system layered on top of Popochiu so the s
 5. **Validation**: Follow the TODO checklist—exercise presets, queue helpers, and PFX combos.
 6. **Packaging**: Optionally wrap the system into a Godot plugin for plug-and-play use across Popochiu projects.
 
-## 5. Notes on Modularisation
+## 6. Notes on Modularisation
 - Popochiu's bundled addons stay untouched; all custom logic lives in `addons/popochiu-addons/` with thin wrappers in the game layer.
 - Any future feature should follow the same pattern: place reusable code under `addons/popochiu-addons/`, documentation under `doc/`, and record migration notes here.
 - If a change requires interacting with core Popochiu logic, consider subclassing or signal forwarding from the game layer instead of modifying the addon.
 
-## 6. Future Work
+## 7. Future Work
 - Build a tiny “cinematic showcase” room demonstrating letterbox + PFX combinations.
 - Polish the Popochiu Addons plugin metadata and publish install instructions for external projects.
 - Add automated headless tests that instantiate the controller, run a tween, and assert final bar offsets and modulate values.

--- a/addons/popochiu-addons/popochiu_addons_plugin.gd
+++ b/addons/popochiu-addons/popochiu_addons_plugin.gd
@@ -5,6 +5,8 @@ const AUTOLOAD_G_NAME := "G"
 const AUTOLOAD_G_PATH := "res://addons/popochiu-addons/wrappers/g_autoload.gd"
 const AUTOLOAD_PFX_NAME := "PFX"
 const AUTOLOAD_PFX_PATH := "res://addons/popochiu-addons/pfx/pfx.gd"
+const AUTOLOAD_HELPER_NAME := "PopochiuHelper"
+const AUTOLOAD_HELPER_PATH := "res://addons/popochiu-addons/wrappers/popochiu_helper.gd"
 const BACKUP_SETTING := "addons/popochiu-addons/autoload_backups"
 
 func _enter_tree() -> void:
@@ -16,13 +18,15 @@ func _enable_plugin() -> void:
 
 
 func _install_autoloads() -> void:
-	var changed = false
-	if _ensure_autoload(AUTOLOAD_PFX_NAME, AUTOLOAD_PFX_PATH, false):
-		changed = true
-	if _ensure_autoload(AUTOLOAD_G_NAME, AUTOLOAD_G_PATH, true):
-		changed = true
-	if changed:
-		ProjectSettings.save()
+        var changed = false
+        if _ensure_autoload(AUTOLOAD_PFX_NAME, AUTOLOAD_PFX_PATH, false):
+                changed = true
+        if _ensure_autoload(AUTOLOAD_HELPER_NAME, AUTOLOAD_HELPER_PATH, true):
+                changed = true
+        if _ensure_autoload(AUTOLOAD_G_NAME, AUTOLOAD_G_PATH, true):
+                changed = true
+        if changed:
+                ProjectSettings.save()
 
 
 func _ensure_autoload(name: String, path: String, store_backup: bool) -> bool:

--- a/addons/popochiu-addons/wrappers/popochiu_helper.gd
+++ b/addons/popochiu-addons/wrappers/popochiu_helper.gd
@@ -1,0 +1,3 @@
+extends "res://addons/popochiu-addons/api/popochiu_helper.gd"
+
+# Wrapper so Popochiu projects can point the PopochiuHelper autoload to the addon implementation.

--- a/addons/popochiu-addons/wrappers/popochiu_helper.gd.uid
+++ b/addons/popochiu-addons/wrappers/popochiu_helper.gd.uid
@@ -1,0 +1,1 @@
+uid://c0rszq1a3w2y5


### PR DESCRIPTION
## Summary
- add configurable prop fade/queue helpers to the G autoload and expose convenience wrappers
- add PopochiuHelper API + wrapper and register it as a plugin autoload
- document prop fade usage across the installation guide, README, and technical docs

## Testing
- /usr/bin/godot --version *(fails: binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d0fa8278832392cd4aa733074b1e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Prop Fade Helpers to fade props in/out with configurable duration, easing, delays, and visibility options.
  - Supports both immediate and queued (blocking) fades for cinematic sequencing.
  - New helper autoload available to access fade utilities from anywhere in your project.
- Documentation
  - Updated installation guide to include the new helper autoload.
  - Expanded feature docs with setup, usage examples, configuration keys, and integration patterns.
  - Enhanced README Quick Start with fade and cinematic verification commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->